### PR TITLE
feat: scrub substring values with their hash

### DIFF
--- a/src/scrubber.test.ts
+++ b/src/scrubber.test.ts
@@ -430,3 +430,32 @@ test('getScrubberSql', () => {
   expect(scrubber.getScrubberSql('pw')).toMatchInlineSnapshot(`"'notsecret'"`)
   expect(scrubber.getScrubberSql('name')).toMatchInlineSnapshot(`"'Jane Doe'"`)
 })
+
+test('macAndIdScrubber should scrub a list of objects', () => {
+  const data = {
+    HardwareDevices: [
+      { id: '123|mac', mac: 'mac', foo: 'bar' },
+      { id: '123|cheese', mac: 'cheese', foo: 'bar' },
+      { id: 'tom', mac: 'tom', foo: 'bar' },
+      { id: 'mac|123|mac', mac: 'mac', foo: 'bar' },
+    ],
+  }
+
+  const result = scrub(data, {
+    fields: {
+      HardwareDevices: {
+        scrubber: 'macAndIdScrubber',
+        params: { otherFieldsToScrub: ['id'] },
+      },
+    },
+  })
+
+  expect(result).toEqual({
+    HardwareDevices: [
+      { id: '123|1', mac: '1', foo: 'bar' },
+      { id: '123|2', mac: '2', foo: 'bar' },
+      { id: '3', mac: '3', foo: 'bar' },
+      { id: '4|123|4', mac: '4', foo: 'bar' },
+    ],
+  })
+})

--- a/src/scrubbers.test.ts
+++ b/src/scrubbers.test.ts
@@ -1,3 +1,4 @@
+import { _stringMapEntries } from '@naturalcycles/js-lib'
 import { nanoid } from '@naturalcycles/nodejs-lib'
 import {
   bcryptStringScrubber,
@@ -26,6 +27,8 @@ import {
   undefinedScrubberSQL,
   unixTimestampScrubber,
   unixTimestampScrubberSQL,
+  defaultScrubbers,
+  defaultScrubbersSQL,
 } from './scrubbers'
 
 const bryptStr1 = '$2a$12$HYNzBb8XYOZZeRwZDiVux.orKNqkSVAoXBDc9Gw7nSxr8rcZupbRK'
@@ -501,4 +504,15 @@ describe('macAndIdScrubber', () => {
 
     expect(macAndIdScrubber(data as any)).toEqual({ mac: '00:00:00:00:00:00' })
   })
+})
+
+const scrubberNames = _stringMapEntries(defaultScrubbers).map(([k]) => k)
+test.each(scrubberNames)('the %s should have its SQL scrubber counterpart', scrubberName => {
+  console.log(scrubberName, defaultScrubbersSQL[scrubberName])
+  expect(defaultScrubbersSQL[scrubberName]).toBeDefined()
+})
+
+const sqlScrubberNames = _stringMapEntries(defaultScrubbersSQL).map(([k]) => k)
+test.each(sqlScrubberNames)('the %s should have its scrubber counterpart', scrubberName => {
+  expect(defaultScrubbers[scrubberName]).toBeDefined()
 })

--- a/src/scrubbers.ts
+++ b/src/scrubbers.ts
@@ -491,9 +491,9 @@ export const saltedHashSubstringScrubberSQL: SaltedHashSubstringScrubberSQLFn = 
   _assert(params?.initializationVector, 'Initialization vector is missing')
   _assert(params?.regex, 'Substring or regex is missing')
 
-  const substringToReplace = `REGEXP_SUBSTR(${sqlValueToReplace}, ${params.regex})`
+  const substringToReplace = `COALESCE(REGEXP_SUBSTR(${sqlValueToReplace}, '${params.regex}'), '')`
   const hashedValue = `SHA2(${substringToReplace} || '${params.initializationVector}', 256)`
-  const replacedValue = `REGEXP_REPLACE(${sqlValueToReplace}, ${params.regex}, ${hashedValue})`
+  const replacedValue = `REGEXP_REPLACE(${sqlValueToReplace}, '${params.regex}', ${hashedValue})`
 
   return replacedValue
 }

--- a/src/scrubbers.ts
+++ b/src/scrubbers.ts
@@ -550,4 +550,5 @@ export const defaultScrubbersSQL: ScrubbersSQLMap = {
   saltedHashScrubber: saltedHashScrubberSQL,
   saltedHashEmailScrubber: saltedHashEmailScrubberSQL,
   bcryptStringScrubber: bcryptStringScrubberSQL,
+  macAndIdScrubber: undefinedScrubberSQL,
 }


### PR DESCRIPTION
In this PR, I added a new scrubber named `saltedHashSubstringScrubber` which behaves similar to `saltedHashScrubber` - with the difference that the new scrubber replaces a substring with the hash rather than the entire value.

The substring can be specified as a string or a regex.
The scrubber takes the substring and hashes it the same way as `saltedHashScrubber`.
Finally it replaces the substring with the hash.

The underlying intention is to be able to replace multiple occurrences of substring with the same replacement value.