### PR TITLE
Keep chars from left scrubber

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^22",
     "@vitest/coverage-v8": "^3",
     "dotenv": "^16",
+    "prettier": "^3",
     "tsx": "^4",
     "vitest": "^3"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/node": "^22",
     "@vitest/coverage-v8": "^3",
     "dotenv": "^16",
-    "prettier": "^3",
     "tsx": "^4",
     "vitest": "^3"
   },

--- a/src/scrubbers.test.ts
+++ b/src/scrubbers.test.ts
@@ -286,7 +286,7 @@ test('keepCharsFromLeftScrubberSQL', () => {
   )
   expect(
     keepCharsFromLeftScrubberSQL({ count: 2, replacement: 'X', replaceFull: true }),
-  ).toMatchInlineSnapshot(`"WHEN LEN(VAL) > 2 THEN SUBSTR(VAL, 0, 2) || 'X' ELSE VAL"`)
+  ).toMatchInlineSnapshot(`"IFF(LEN(VAL) > 2, SUBSTR(VAL, 0, 2) || 'X', VAL)"`)
 })
 
 describe('randomScrubber', () => {

--- a/src/scrubbers.ts
+++ b/src/scrubbers.ts
@@ -275,7 +275,7 @@ export const keepCharsFromLeftScrubberSQL: KeepCharsFromLeftScrubberSQLFn = (
 
   if (replaceFull) {
     // keep $count chars from the left, and replace rest by $replacement
-    return `WHEN LEN(${sqlValueToReplace}) > ${count} THEN SUBSTR(${sqlValueToReplace}, 0, ${count}) || '${replacement}' ELSE ${sqlValueToReplace}`
+    return `IFF(LEN(${sqlValueToReplace}) > ${count}, SUBSTR(${sqlValueToReplace}, 0, ${count}) || '${replacement}', ${sqlValueToReplace})`
   }
   // keep $count chars and fill out with $replacement if string was longer
   return `SUBSTR(${sqlValueToReplace}, 0, ${count}) || REPEAT('${replacement}', LEAST(0, LEN(${sqlValueToReplace})-${count})`

--- a/src/scrubbers.ts
+++ b/src/scrubbers.ts
@@ -259,7 +259,7 @@ export const keepCharsFromLeftScrubber: KeepCharsFromLeftScrubberFn = (
 
   const { count, replacement, replaceFull } = params
 
-  if (value.length >= count) {
+  if (value.length <= count) {
     return value
   }
   if (replaceFull) {


### PR DESCRIPTION
Adding a keepCharsFromLeft scrubber.

Some zip codes can be longer than 5 chars but we still want to keep 3 from the left.