### PR TITLE
feat(data): Adding ifMatch filtering for static scrubber

### DIFF
--- a/src/scrubbers.test.ts
+++ b/src/scrubbers.test.ts
@@ -98,7 +98,7 @@ test('staticScrubberSQL', () => {
   expect(staticScrubberSQL({ replacement: 'hello world' })).toMatchInlineSnapshot(`"'hello world'"`)
   expect(staticScrubberSQL({ replacement: 12345 })).toMatchInlineSnapshot(`"12345"`)
   expect(staticScrubberSQL({ ifMatch: '.*V.RY.*LL.*', replacement: 12345 })).toMatchInlineSnapshot(
-    `"CASE WHEN LIKE(VAL, '.*V.RY.*LL.*') THEN 12345 ELSE VAL END"`,
+    `"CASE WHEN REGEXP_LIKE(VAL, '.*V.RY.*LL.*') THEN 12345 ELSE VAL END"`,
   )
 })
 

--- a/src/scrubbers.test.ts
+++ b/src/scrubbers.test.ts
@@ -98,7 +98,7 @@ test('staticScrubberSQL', () => {
   expect(staticScrubberSQL({ replacement: 'hello world' })).toMatchInlineSnapshot(`"'hello world'"`)
   expect(staticScrubberSQL({ replacement: 12345 })).toMatchInlineSnapshot(`"12345"`)
   expect(staticScrubberSQL({ ifMatch: '.*V.RY.*LL.*', replacement: 12345 })).toMatchInlineSnapshot(
-    `"12345"`,
+    `"CASE WHEN LIKE(VAL, '.*V.RY.*LL.*') THEN 12345 ELSE VAL END"`,
   )
 })
 

--- a/src/scrubbers.test.ts
+++ b/src/scrubbers.test.ts
@@ -66,8 +66,8 @@ describe('staticScrubber', () => {
   test.each([
     [undefined, 'replacement'],
     ['', 'replacement'],
-  ])('handles undefined values "%s" > "%s"', (_input, replacement) => {
-    const result = staticScrubber('', { replacement: 'replacement' })
+  ])('handles undefined values "%s" > "%s"', (input, replacement) => {
+    const result = staticScrubber(input, { replacement: 'replacement' })
     expect(result).toEqual(replacement)
   })
 
@@ -84,11 +84,22 @@ describe('staticScrubber', () => {
 
     expect(staticScrubber(secretNum, { replacement: r })).toEqual(r)
   })
+
+  test.each([
+    ['wontmatch', 'wontmatch'],
+    ['could VERYWELL match', 'replacement'],
+  ])('replaces only ifMatch matches "%s" > "%s"', (input, replacement) => {
+    const result = staticScrubber(input, { ifMatch: '.*V.RY.*LL.*', replacement: 'replacement' })
+    expect(result).toEqual(replacement)
+  })
 })
 
 test('staticScrubberSQL', () => {
   expect(staticScrubberSQL({ replacement: 'hello world' })).toMatchInlineSnapshot(`"'hello world'"`)
   expect(staticScrubberSQL({ replacement: 12345 })).toMatchInlineSnapshot(`"12345"`)
+  expect(staticScrubberSQL({ ifMatch: '.*V.RY.*LL.*', replacement: 12345 })).toMatchInlineSnapshot(
+    `"12345"`,
+  )
 })
 
 describe('unixTimestampScrubber', () => {

--- a/src/scrubbers.ts
+++ b/src/scrubbers.ts
@@ -603,5 +603,5 @@ export const defaultScrubbersSQL: ScrubbersSQLMap = {
 
 const wrapIfMatchSQL = (ifMatch: string | undefined, expression: string): string => {
   if (ifMatch === undefined) return expression
-  return `CASE WHEN LIKE(${sqlValueToReplace}, '${ifMatch}') THEN ${expression} ELSE ${sqlValueToReplace} END`
+  return `CASE WHEN REGEXP_LIKE(${sqlValueToReplace}, '${ifMatch}') THEN ${expression} ELSE ${sqlValueToReplace} END`
 }

--- a/src/scrubbers.ts
+++ b/src/scrubbers.ts
@@ -48,20 +48,24 @@ export const preserveOriginalScrubberSQL: PreserveOriginalScrubberSQLFn = () => 
  Replace value with `params.replacement`
  */
 export interface StaticScrubberParams {
+  /**
+   * Only scrub if value matches given Regex
+   */
+  ifMatch?: string
   replacement: string | number
 }
 export type StaticScrubberFn = ScrubberFn<any, StaticScrubberParams>
 
 export type StaticScrubberSQLFn = ScrubberSQLFn<StaticScrubberParams>
 
-export const staticScrubber: StaticScrubberFn = (_value, params = { replacement: '' }) =>
-  params.replacement
+export const staticScrubber: StaticScrubberFn = (value, params = { replacement: '' }) =>
+  (params.ifMatch && !value.match(params.ifMatch) && value) || params.replacement
 
 export const staticScrubberSQL: StaticScrubberSQLFn = (params = { replacement: '' }) => {
-  const { replacement } = params
+  const { ifMatch, replacement } = params
   const type = typeof replacement === 'number' ? 'NUMBER' : 'STRING'
 
-  return encloseValueForSQL(replacement, type)
+  return wrapIfMatchSQL(ifMatch, encloseValueForSQL(replacement, type))
 }
 /*
  ISO Date string scrubber
@@ -595,4 +599,9 @@ export const defaultScrubbersSQL: ScrubbersSQLMap = {
   bcryptStringScrubber: bcryptStringScrubberSQL,
   saltedHashSubstringScrubber: saltedHashSubstringScrubberSQL,
   keepCharsFromLeftScrubber: keepCharsFromLeftScrubberSQL,
+}
+
+const wrapIfMatchSQL = (ifMatch: string | undefined, expression: string): string => {
+  if (ifMatch === undefined) return expression
+  return `CASE WHEN LIKE(${sqlValueToReplace}, '${ifMatch}') THEN ${expression} ELSE ${sqlValueToReplace} END`
 }


### PR DESCRIPTION
Adding the possibility to only scrub values matching a regex.
The regex needs to work in both javascript and SQL.

Making `wrapIfMatchSQL` a separate function with the thought that it could be included in all scrubbers as a general filtering function later, or easily added to single scrubbers when needed.