### PR TITLE
fix(data): Improving the email matcher for modern TLDs

### DIFF
--- a/src/scrubbers.test.ts
+++ b/src/scrubbers.test.ts
@@ -384,8 +384,6 @@ describe('randomEmailInContentScrubber', () => {
     const text = 'Foo bar baz qux@quux.corge grault'
     const result = randomEmailInContentScrubber(text)
 
-    console.log(result)
-
     expect(result).not.toContain('qux@quux.corge')
     expect(result).not.toContain(' qux')
     expect(result).not.toContain('ge grault') // not matching the full email

--- a/src/scrubbers.test.ts
+++ b/src/scrubbers.test.ts
@@ -379,20 +379,32 @@ describe('randomEmailInContentScrubber', () => {
     expect(result).not.toContain('example.com.br') // test multi.dot domains
     expect(result).toContain(suffix)
   })
+
+  test('scrub complex email with long TLD in text', () => {
+    const text = 'Foo bar baz qux@quux.corge grault'
+    const result = randomEmailInContentScrubber(text)
+
+    console.log(result)
+
+    expect(result).not.toContain('qux@quux.corge')
+    expect(result).not.toContain(' qux')
+    expect(result).not.toContain('ge grault') // not matching the full email
+    expect(result).toContain('Foo bar baz ')
+  })
 })
 
 test('randomEmailInContentScrubberSQL', () => {
   expect(randomEmailInContentScrubberSQL()).toMatchInlineSnapshot(`
     "REGEXP_REPLACE(
         VAL,
-        '[a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\\.[a-zA-Z_-]{2,3}',
+        '[a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\\.[a-zA-Z_-]{2,63}',
         RANDSTR(16, HASH(RANDOM()))
       ) || '@example.com'"
   `)
   expect(randomEmailInContentScrubberSQL({ length: 5 })).toMatchInlineSnapshot(`
     "REGEXP_REPLACE(
         VAL,
-        '[a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\\.[a-zA-Z_-]{2,3}',
+        '[a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\\.[a-zA-Z_-]{2,63}',
         RANDSTR(5, HASH(RANDOM()))
       ) || '@example.com'"
   `)
@@ -400,7 +412,7 @@ test('randomEmailInContentScrubberSQL', () => {
     .toMatchInlineSnapshot(`
       "REGEXP_REPLACE(
           VAL,
-          '[a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\\.[a-zA-Z_-]{2,3}',
+          '[a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\\.[a-zA-Z_-]{2,63}',
           RANDSTR(5, HASH(RANDOM()))
         ) || '@customdomain.com'"
     `)

--- a/src/scrubbers.ts
+++ b/src/scrubbers.ts
@@ -371,7 +371,7 @@ export const randomEmailInContentScrubber: RandomEmailInContentScrubberFn = (
   additionalParams,
 ) => {
   // Email regex, allows letters
-  const emailRegex = /([a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\.[a-zA-Z_-]{2,3})/
+  const emailRegex = /([a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\.[a-zA-Z_-]{2,63})/
   const matches = emailRegex.exec(value)
   if (!matches) {
     // No email found, return as is
@@ -394,7 +394,7 @@ export const randomEmailInContentScrubberSQL: RandomEmailInContentScrubberSQLFn 
     }
     return `REGEXP_REPLACE(
     ${sqlValueToReplace},
-    '[a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\\.[a-zA-Z_-]{2,3}',
+    '[a-zA-Z1-9._-]*@[a-zA-Z1-9._-]*\\.[a-zA-Z_-]{2,63}',
     RANDSTR(${length}, ${randomGeneratorSeed})
   ) || '${domain}'`
   }


### PR DESCRIPTION
Modern top level domains can be up to 63 characters long.